### PR TITLE
Skip malformed source map URL

### DIFF
--- a/public/javascripts/index.js
+++ b/public/javascripts/index.js
@@ -88,9 +88,11 @@ sourcemapsApp.controller('LoadController', ['$scope', '$http', function ($scope,
 
             response.data.split("\n").forEach(function (line) {
                 var match = line.match(/(?:\/\/|\/\*) *# *sourceMappingURL *= *([^ ]*)/);
-
+                
                 if (match) {
-                    $scope.script.mapUrl = URI(match[1]).absoluteTo($scope.script.url).toString();
+                    try {
+                        $scope.script.mapUrl = URI(match[1]).absoluteTo($scope.script.url).toString();
+                    } catch (e) {}
                 }
             });
 


### PR DESCRIPTION
Can't parse this stack trace because emotion has code that generates source maps dynamically. The javascript is incorrectly taking that part of code as the source map of the file.

```
Error: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at lu (https://confluence-v1-canary.prod.atl-paas.net/master/vendors~4134d62c.58TNxf4h83.js:2:661625)
    at hs (https://confluence-v1-canary.prod.atl-paas.net/master/vendors~4134d62c.58TNxf4h83.js:2:674814)
    at t.unstable_runWithPriority (https://confluence-v1-canary.prod.atl-paas.net/master/vendors~4134d62c.58TNxf4h83.js:2:438387)
    at Qo (https://confluence-v1-canary.prod.atl-paas.net/master/vendors~4134d62c.58TNxf4h83.js:2:619980)
    at ps (https://confluence-v1-canary.prod.atl-paas.net/master/vendors~4134d62c.58TNxf4h83.js:2:672674)
    at Zu (https://confluence-v1-canary.prod.atl-paas.net/master/vendors~4134d62c.58TNxf4h83.js:2:668828)
    at https://confluence-v1-canary.prod.atl-paas.net/master/vendors~4134d62c.58TNxf4h83.js:2:620271
    at t.unstable_runWithPriority (https://confluence-v1-canary.prod.atl-paas.net/master/vendors~4134d62c.58TNxf4h83.js:2:438387)
    at Qo (https://confluence-v1-canary.prod.atl-paas.net/master/vendors~4134d62c.58TNxf4h83.js:2:619980)
    at Yo (https://confluence-v1-canary.prod.atl-paas.net/master/vendors~4134d62c.58TNxf4h83.js:2:620216)
```